### PR TITLE
Add web UI for chatbot features

### DIFF
--- a/features/baseline-chatbot/README.md
+++ b/features/baseline-chatbot/README.md
@@ -38,6 +38,8 @@ cp app/.env.example app/.env
 python app/main.py
 ```
 
+Then open [http://127.0.0.1:5000/](http://127.0.0.1:5000/) in your browser to use the simple web UI.
+
 ### 6. Test the endpoint
 ```bash
 curl -X POST http://127.0.0.1:5000/chat -H "Content-Type: application/json" -d '{"prompt": "Tell me a joke."}'

--- a/features/baseline-chatbot/app/main.py
+++ b/features/baseline-chatbot/app/main.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder="static", static_url_path="")
 
 AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT")
 AZURE_OPENAI_KEY = os.getenv("AZURE_OPENAI_KEY")
@@ -31,6 +31,11 @@ def chat():
 
     response = requests.post(url, headers=headers, json=body)
     return jsonify(response.json())
+
+
+@app.get("/")
+def index():
+    return app.send_static_file("index.html")
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/features/baseline-chatbot/app/static/index.html
+++ b/features/baseline-chatbot/app/static/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Chatbot</title>
+</head>
+<body>
+  <h1>Azure OpenAI Chatbot</h1>
+  <textarea id="prompt" rows="4" cols="50" placeholder="Enter your question"></textarea><br>
+  <button id="send">Send</button>
+  <pre id="response"></pre>
+
+<script>
+  document.getElementById('send').onclick = async () => {
+    const prompt = document.getElementById('prompt').value;
+    const res = await fetch('/chat', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({prompt})
+    });
+    const data = await res.json();
+    document.getElementById('response').textContent = JSON.stringify(data, null, 2);
+  };
+</script>
+</body>
+</html>

--- a/features/entra-auth/README.md
+++ b/features/entra-auth/README.md
@@ -4,7 +4,7 @@ This version of the chatbot adds Entra ID (Azure AD) authentication to the `/cha
 
 ## 🚀 How to Run
 
-1. Set up an App Registration in Entra ID  
+1. Set up an App Registration in Entra ID
 2. Configure `.env` with the following values:
    - `AZURE_TENANT_ID`
    - `AZURE_CLIENT_ID`
@@ -14,3 +14,6 @@ This version of the chatbot adds Entra ID (Azure AD) authentication to the `/cha
 ```bash
 pip install -r requirements.txt
 python main.py
+```
+
+Open [http://127.0.0.1:5000/](http://127.0.0.1:5000/) in your browser and authenticate to use the web UI.

--- a/features/entra-auth/app/main.py
+++ b/features/entra-auth/app/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify, redirect
+from flask import Flask, request, jsonify
 from auth_config import require_auth
 import os
 import requests
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder="static", static_url_path="")
 
 AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT")
 AZURE_OPENAI_KEY = os.getenv("AZURE_OPENAI_KEY")
@@ -36,9 +36,9 @@ def chat():
 
     return jsonify(response.json())
 
-@app.route("/")
+@app.get("/")
 def index():
-    return redirect("/chat")
+    return app.send_static_file("index.html")
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/features/entra-auth/app/static/index.html
+++ b/features/entra-auth/app/static/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Chatbot</title>
+</head>
+<body>
+  <h1>Azure OpenAI Chatbot</h1>
+  <textarea id="prompt" rows="4" cols="50" placeholder="Enter your question"></textarea><br>
+  <button id="send">Send</button>
+  <pre id="response"></pre>
+
+<script>
+  document.getElementById('send').onclick = async () => {
+    const prompt = document.getElementById('prompt').value;
+    const res = await fetch('/chat', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({prompt})
+    });
+    const data = await res.json();
+    document.getElementById('response').textContent = JSON.stringify(data, null, 2);
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static web UI from root route in both features
- provide simple JavaScript frontend that calls `/chat`
- document browser usage in each feature's README

## Testing
- `python -m py_compile features/baseline-chatbot/app/main.py`
- `python -m py_compile features/entra-auth/app/main.py features/entra-auth/app/auth_config.py`


------
https://chatgpt.com/codex/tasks/task_e_684a95704d8c832798906d4130bc14a8